### PR TITLE
feat: Publishing of Snapshots into Github Packages (instead of Maven Central)

### DIFF
--- a/.github/workflows/maven-central-snapshot-deploy.yaml
+++ b/.github/workflows/maven-central-snapshot-deploy.yaml
@@ -25,6 +25,9 @@ permissions:
   contents: read
   packages: write
 
+env:
+  additional-mvn-args: ""
+
 jobs:
   mvn-snapshot-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/maven-central-snapshot-deploy.yaml
+++ b/.github/workflows/maven-central-snapshot-deploy.yaml
@@ -31,9 +31,9 @@ jobs:
     with:
       java-version: "21"
       additional-mvn-args: ""
-      target-store: "maven-central"
+      target-store: "github"
     secrets:
-      maven-username: ${{ secrets.MAVEN_USER }}
-      maven-token: ${{ secrets.MAVEN_PASSWORD }}
-      gpg-passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+      maven-username: ${{ github.ACTOR }}
+      maven-token: ${{ secrets.GITHUB_TOKEN }}
+      gpg-passphrase: ${{ secrets.GPG-PASSPHRASE }}
       gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}

--- a/.github/workflows/maven-central-snapshot-deploy.yaml
+++ b/.github/workflows/maven-central-snapshot-deploy.yaml
@@ -1,5 +1,5 @@
 ---
-# The workflow to deploy snapshot artifact versions to Maven Central
+# The workflow to deploy snapshot artifact versions to Github Pachages
 # Fill free to adjust java version and additional mvn command-line parameters
 # The workflow will trigger on pushes into branches different from main and release
 # Please make sure that the version in the pom.xml file has the SNAPSHOT postfix

--- a/.github/workflows/maven-central-snapshot-deploy.yaml
+++ b/.github/workflows/maven-central-snapshot-deploy.yaml
@@ -27,13 +27,19 @@ permissions:
 
 jobs:
   mvn-snapshot-deploy:
-    uses: netcracker/qubership-workflow-hub/.github/workflows/re-maven-snapshot-deploy.yaml@v1.0.7
-    with:
-      java-version: "21"
-      additional-mvn-args: ""
-      target-store: "github"
-    secrets:
-      maven-username: ${{ github.ACTOR }}
-      maven-token: ${{ secrets.GITHUB_TOKEN }}
-      gpg-passphrase: ${{ secrets.GPG-PASSPHRASE }}
-      gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Maven Docker build
+        id: maven_build
+        uses: netcracker/qubership-workflow-hub/actions/maven-snapshot-deploy@9538833017019ab6bbc2138d3034778dfe3a5d1f # v2.0.6
+        with:
+          java-version: "21"
+          additional-mvn-args: ${{ env.additional-mvn-args }}
+          target-store: "github"
+          maven-username: ${{ github.ACTOR }}
+          maven-token: ${{ secrets.GITHUB_TOKEN }}
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: ${{ secrets.GPG-PASSPHRASE }}

--- a/pom.xml
+++ b/pom.xml
@@ -623,3 +623,4 @@
         </pluginRepository>
     </pluginRepositories>
 </project>
+

--- a/pom.xml
+++ b/pom.xml
@@ -623,4 +623,3 @@
         </pluginRepository>
     </pluginRepositories>
 </project>
-


### PR DESCRIPTION
Published snapshot version to Github Packages


<!-- start messages -->
### Commit messages:
[dale1020](https://github.com/Netcracker/qubership-testing-platform-macros-core-library/commit/b4a00883419c990eef5a79804e7c951b5103a765) try github publication
[dale1020](https://github.com/Netcracker/qubership-testing-platform-macros-core-library/commit/62c6eaccaa165ebadf7c5eb90ead01a20dbf52fb) try github publication
[dale1020](https://github.com/Netcracker/qubership-testing-platform-macros-core-library/commit/74d2fe9f2907818b6c8104b97fa235ae4aca387d) try github publication
[dale1020](https://github.com/Netcracker/qubership-testing-platform-macros-core-library/commit/cadbbadb04e279ab321e918df85b64ff2727b5b3) try github publication
[dale1020](https://github.com/Netcracker/qubership-testing-platform-macros-core-library/commit/4a9c7c3a02cffccb807377dcb80c86501780f417) add additional-mvn-args
<!-- end messages -->


